### PR TITLE
Fix problems of empty data

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -14,7 +14,7 @@ function lnCmsController($rootScope, $scope, lnCmsClientService, $urlRouter) {
   vm.static = null;
   vm.view = null;
 
-  $rootScope.$on('$stateChangeStart', 
+  $rootScope.$on('$stateChangeStart',
     function(event, toState, toParams, fromState, fromParams, options){
       var jsonToParams = toParams ? angular.toJson(toParams) : '';
       var jsonFromParams = fromParams ? angular.toJson(fromParams) : '';
@@ -39,13 +39,16 @@ function lnCmsController($rootScope, $scope, lnCmsClientService, $urlRouter) {
         //load view
         lnCmsClientService.getView(endpoint, params)
           .then(function(response) {
-            if (response.data.length > 0)
+            if (response.data.length > 0) {
               vm.view = response.data[0];
+            } else if (response.data) {
+              vm.view = response.data;
+            }
           });
       }
     });
 
-  $rootScope.$on('$locationChangeSuccess', 
+  $rootScope.$on('$locationChangeSuccess',
     function(event) {
       event.preventDefault();
 


### PR DESCRIPTION
In some cases the data returned is not an array, and we don't have the
`length` property, in those case we can just simple return the plain
data.
