### PR TITLE
Handle erros on the request to 404 URLS

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -6,9 +6,9 @@ angular
   .module('lnCms')
   .controller('LnCmsController', lnCmsController);
 
-lnCmsController.$inject = ['$rootScope', '$scope', 'lnCmsClientService', '$urlRouter'];
+lnCmsController.$inject = ['$rootScope', '$scope', 'lnCmsClientService', '$urlRouter', '$state'];
 
-function lnCmsController($rootScope, $scope, lnCmsClientService, $urlRouter) {
+function lnCmsController($rootScope, $scope, lnCmsClientService, $urlRouter, $state) {
   var vm = this;
 
   vm.static = null;
@@ -49,7 +49,7 @@ function lnCmsController($rootScope, $scope, lnCmsClientService, $urlRouter) {
           } else if (response.data) {
             vm.view = response.data;
           }
-        });
+        }, onError);
       }
     }
   }
@@ -76,7 +76,13 @@ function lnCmsController($rootScope, $scope, lnCmsClientService, $urlRouter) {
       .then(function(response) {
         vm.static = response.data;
         cb();
-      });
+      }, onError);
+    }
+  }
+
+  function onError(response){
+    if ( response.status === 404 ) {
+      $state.go('404');
     }
   }
 }


### PR DESCRIPTION
At the moment we can make `n` amount of request to invalid URLS and the
FE will always mantain the current state. Ideally or in a normal
scenario on an invalid request to the view we end up on the 404 page.

With this change we handle the errors created by the $http requests and
move to the 404 view.

Fixes #19
