### PR TITLE
Remove ui-view parameter attributes from view directive template.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
+#NPM
 node_modules/
+*.log
+
+#IDE Specific
+.idea
+
+#Package
+ln-cms-*.tgz

--- a/lib/view.directive.js
+++ b/lib/view.directive.js
@@ -11,7 +11,7 @@ function lnCmsView($state) {
   return {
     restrict: 'E',
     link: link,
-    template: '<div ui-view view-def="{{viewDef}}" static-def="{{staticDef}}"></div>',
+    template: '<div ui-view></div>',
     scope: {
       viewDef: '@',
       staticDef: '@'


### PR DESCRIPTION
This PR removes the viewDef and staticDef parameters from the template attributes of the view directive. These attributes are not actually needed at the child _div_ because their values are taken from the parent tag _ln-cms-view_. Also this removes an overhead in the resulting html.
