### PR TITLE
Cached data

### DIFF
--- a/lib/cms.client.service.js
+++ b/lib/cms.client.service.js
@@ -27,6 +27,10 @@ function lnCmsService($http, lnCmsConfig) {
       return $http.get( endpoint + '/' + params.id );
     }
 
-    return $http.get( endpoint, {params: params} );
+    var options = {
+      params: params,
+      cache: true,
+    };
+    return $http.get( endpoint, options );
   }
 }

--- a/lib/cms.view.directive.js
+++ b/lib/cms.view.directive.js
@@ -38,7 +38,7 @@ function lnCmsView($state) {
       if (!scope.viewDef || scope.viewDef.trim() == '') {
         return;
       }
-      
+
       scope.view = angular.fromJson(scope.viewDef);
 
       if (!$state.current.abstract)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ln-cms",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Moxie <developer@getmoxied.net> (https://getmoxied.net)",
   "description": "An angularjs module for loading content from a cms.",
   "main": "index.js",


### PR DESCRIPTION
Cached `http` requests in order to avoid having multiple requests to the same endpoint, since the GF component is expecting the data of the endpoint before the request is completed and that triggers multiple requests.
