### PR TITLE
2.0.0 - Fixes on multiple reload calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,14 +15,8 @@ var lnCms = angular.module('lnCms', [
   }
 ])
 
-.run(['lnCmsClientService', '$urlRouter', '$state',
-  function(lnCmsClientService, $urlRouter, $state) {
-    //add intermediate loading state which can be used for transitions animations
-    lnCms.stateProvider.state({
-      name: 'loading',
-      templateUrl: 'templates/loading/template.html'
-    });
-
+.run(['lnCmsClientService', '$urlRouter', '$state', '$q',
+  function(lnCmsClientService, $urlRouter, $state, $q) {
     //add error state
     lnCms.stateProvider.state({
       name: '503',
@@ -39,6 +33,17 @@ var lnCms = angular.module('lnCms', [
             name: route.state,
             url: route.url,
             templateUrl: 'templates/' + route.template + '/template.html',
+            controller: 'LnViewController as vm',
+            resolve: {
+              staticData:function(){
+                return lnCmsClientService.getStatic();
+              },
+              viewData: function(){
+                var endpoint = route.endpoint || 'post';
+                var params = route.params || {};
+                return lnCmsClientService.getData(endpoint, params);
+              }
+            },
             data: {
               endpoint: (route.endpoint || 'post'),
               fixedParams: (route.params || {}),
@@ -51,13 +56,17 @@ var lnCms = angular.module('lnCms', [
           }
 
           if (route.url == '/') {
-            //define default state for the empty url
-            var defState = JSON.parse(JSON.stringify(state));
+            // //define default state for the empty url
+            var defState = {};
+            angular.copy(state, defState);
             defState.name = 'default';
             defState.url = '';
             lnCms.stateProvider.state(defState);
+          } else if ( route.state === '404' ) {
+            state.resolve.viewData = function() {
+              return $q.when({});
+            }
           }
-
           //add state for the route
           lnCms.stateProvider.state(state);
         });
@@ -74,5 +83,6 @@ var lnCms = angular.module('lnCms', [
 require('./lib/cms.config.provider');
 require('./lib/cms.client.service');
 require('./lib/cms.controller');
+require('./lib/cms-ln-view.controller');
 require('./lib/cms.meta.directive');
 require('./lib/cms.view.directive');

--- a/index.js
+++ b/index.js
@@ -35,14 +35,15 @@ var lnCms = angular.module('lnCms', [
             templateUrl: 'templates/' + route.template + '/template.html',
             controller: 'LnViewController as vm',
             resolve: {
-              staticData:function(){
+              staticData: ['lnCmsClientService', function(lnCmsClientService){
                 return lnCmsClientService.getStatic();
-              },
-              viewData: function(){
+              }],
+              viewData: ['lnCmsClientService', '$stateParams', function(lnCmsClientService, $stateParams){
                 var endpoint = route.endpoint || 'post';
                 var params = route.params || {};
+                angular.merge(params, $stateParams);
                 return lnCmsClientService.getData(endpoint, params);
-              }
+              }],
             },
             data: {
               endpoint: (route.endpoint || 'post'),
@@ -51,11 +52,6 @@ var lnCms = angular.module('lnCms', [
             }
           };
 
-          if (route.stateParams) {
-            state.params = route.stateParams;
-          }
-
-          var requestView = 'request' in route && route.request;
           if (route.url == '/') {
             // //define default state for the empty url
             var defState = {};
@@ -63,7 +59,7 @@ var lnCms = angular.module('lnCms', [
             defState.name = 'default';
             defState.url = '';
             lnCms.stateProvider.state(defState);
-          } else if ( ! requestView || route.state === '404' ) {
+          } else if ( ! state.data.request || route.state === '404' ) {
             state.resolve.viewData = function _resolve() {
               return $q.when({});
             }

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ var lnCms = angular.module('lnCms', [
             state.params = route.stateParams;
           }
 
+          var requestView = 'request' in route && route.request;
           if (route.url == '/') {
             // //define default state for the empty url
             var defState = {};
@@ -62,8 +63,8 @@ var lnCms = angular.module('lnCms', [
             defState.name = 'default';
             defState.url = '';
             lnCms.stateProvider.state(defState);
-          } else if ( route.state === '404' ) {
-            state.resolve.viewData = function() {
+          } else if ( ! requestView || route.state === '404' ) {
+            state.resolve.viewData = function _resolve() {
               return $q.when({});
             }
           }

--- a/index.js
+++ b/index.js
@@ -45,11 +45,7 @@ var lnCms = angular.module('lnCms', [
                 return lnCmsClientService.getData(endpoint, params);
               }],
             },
-            data: {
-              endpoint: (route.endpoint || 'post'),
-              fixedParams: (route.params || {}),
-              request: 'request' in route ? route.request : true
-            }
+            request: 'request' in route ? route.request : true,
           };
 
           if (route.url == '/') {
@@ -59,7 +55,7 @@ var lnCms = angular.module('lnCms', [
             defState.name = 'default';
             defState.url = '';
             lnCms.stateProvider.state(defState);
-          } else if ( ! state.data.request || route.state === '404' ) {
+          } else if ( ! state.request || route.state === '404' ) {
             state.resolve.viewData = function _resolve() {
               return $q.when({});
             }

--- a/lib/cms-ln-view.controller.js
+++ b/lib/cms-ln-view.controller.js
@@ -1,0 +1,12 @@
+angular
+  .module('lnCms')
+  .controller('LnViewController', lnViewController);
+
+lnViewController.$inject = ['$rootScope', 'viewData', 'staticData'];
+
+function lnViewController($rootScope, viewData, staticData) {
+  var vm = this;
+  vm.static = staticData.data;
+  vm.view = viewData.data;
+  $rootScope.$emit('staticDataUpdated', vm.view);
+}

--- a/lib/cms.client.service.js
+++ b/lib/cms.client.service.js
@@ -4,17 +4,15 @@ angular
   .module('lnCms')
   .factory('lnCmsClientService', lnCmsService);
 
-lnCmsService.$inject = ['$http', 'lnCmsConfig'];
+lnCmsService.$inject = ['$http', 'lnCmsConfig', '$document'];
 
-function lnCmsService($http, lnCmsConfig) {
-
+function lnCmsService($http, lnCmsConfig, $document) {
+  var doc = $document[0];
   return {
     getRoutes: getRoutes,
     getStatic: getStatic,
     getData: getData,
-    enableLoadingState: false,
-    nextState: null,
-    nextParams: null
+    hasLoader: _hasLoader,
   };
 
   function getRoutes() {
@@ -36,5 +34,9 @@ function lnCmsService($http, lnCmsConfig) {
       options.params = params;
       return $http.get( endpoint, options );
     }
+  }
+
+  function _hasLoader() {
+    return doc.body.getAttribute('data-has-loader') === 'true';
   }
 }

--- a/lib/cms.controller.js
+++ b/lib/cms.controller.js
@@ -1,23 +1,27 @@
 require('./cms.client.service');
+var raf = require('raf')
 
 angular
   .module('lnCms')
   .controller('LnCmsController', lnCmsController);
 
 lnCmsController.$inject = ['$rootScope', 'lnCmsClientService', '$state', '$window'];
-
 function lnCmsController($rootScope, lnCmsClientService, $state, $window) {
   var vm = this;
+  vm.isLoading = lnCmsClientService.hasLoader();
+  vm.meta = {};
 
-  vm.static = null;
-  vm.view = null;
+  $rootScope.$on('staticDataUpdated', function(e, view) {
+    if ( ! angular.isDefined( view ) ) {
+      return;
+    }
 
-  //load static data
-  lnCmsClientService
-    .getStatic()
-    .then(function success(response) {
-      vm.static = response.data;
-    }, onError);
+    if ( angular.isArray(view) && angular.isDefined( view[0].meta ) ) {
+      vm.meta = view[0].meta;
+    } else if ( angular.isDefined( view.meta ) ) {
+      vm.meta = view.meta;
+    }
+  });
 
   $rootScope.$on('$stateChangeStart', stateChangeStart);
   $rootScope.$on('$stateChangeSuccess', stateChangeSuccess);
@@ -28,81 +32,18 @@ function lnCmsController($rootScope, lnCmsClientService, $state, $window) {
   }
 
   function stateChangeStart(event, toState, toParams, fromState, fromParams, options) {
-    if (toState.url === '/' && toState.name !== 'default') {
-      //go directly to default state instead of passing through an intermediate home state
-      event.preventDefault();
-      $state.go('default');
-    } else if (fromState.name === 'loading' && toState.name === 'loading') {
-      //view data was completely loaded and the state reload was triggered by the directive
-      //go to the next state that we had stored before going to the loading state
-      event.preventDefault();
-      $state.go(lnCmsClientService.nextState.name, lnCmsClientService.nextParams);
-    } else if (fromState.name !== 'loading' && toState.name !== 'loading') {
-      //normal state change
-      //if enableLoadingState is true, we store the next state and params and go to the loading state
-      //while the view data is fetched from the backend
-      var jsonToParams = toParams ? angular.toJson(toParams) : '';
-      var jsonFromParams = fromParams ? angular.toJson(fromParams) : '';
-
-      if (toState.data && (toState.name != fromState.name || jsonToParams != jsonFromParams)) {
-        var endpoint = toState.data.endpoint;
-        var fixedParams = toState.data.fixedParams;
-        var request = toState.data.request;
-        var params = {};
-        
-        //reset view to clean data before the request.
-        if (vm.view) {
-          vm.view = null;
-        }
-
-        //load view
-        if (request || !vm.static) {
-          if (lnCmsClientService.enableLoadingState) {
-            event.preventDefault();
-            lnCmsClientService.nextState = toState;
-            lnCmsClientService.nextParams = toParams;
-          }
-
-          if (request) {
-            //load fixed parameters
-            for (var key in fixedParams) {
-              if (fixedParams.hasOwnProperty(key))
-                params[key] = fixedParams[key];
-            }
-
-            //load url parameters
-            for (var key in toParams) {
-              if (toParams.hasOwnProperty(key) ) {
-                params[key] = toParams[key];
-              }
-            }
-          
-            lnCmsClientService
-              .getData(endpoint, params)
-              .then(function success(response) {
-                vm.view = response.data;
-
-                if ( angular.isArray( vm.view ) && angular.isDefined( vm.view[0].meta ) ) {
-                  vm.meta = vm.view[0].meta;
-                } else if ( angular.isDefined( vm.view.meta ) ) {
-                  vm.meta = vm.view.meta;
-                }
-              }, onError);
-          }
-
-          if (lnCmsClientService.enableLoadingState) {
-            $state.go('loading');
-          }
-        }
-      }
-    }
+    vm.isLoading = lnCmsClientService.hasLoader();
   }
 
   function stateChangeSuccess() {
     document.body.scrollTop = document.documentElement.scrollTop = 0;
-
     if ( $window.ga ) {
       $window.ga( 'send', 'pageview', { page: getCurrentAbsoluteUrl() } );
+    }
+    if ( lnCmsClientService.hasLoader() ) {
+      raf(function() {
+        vm.isLoading = false;
+      });
     }
   }
 

--- a/lib/cms.controller.js
+++ b/lib/cms.controller.js
@@ -16,7 +16,7 @@ function lnCmsController($rootScope, lnCmsClientService, $state, $window) {
       return;
     }
 
-    if ( angular.isArray(view) && angular.isDefined( view[0].meta ) ) {
+    if ( angular.isArray(view) && view.length && angular.isDefined( view[0].meta ) ) {
       vm.meta = view[0].meta;
     } else if ( angular.isDefined( view.meta ) ) {
       vm.meta = view.meta;
@@ -31,7 +31,7 @@ function lnCmsController($rootScope, lnCmsClientService, $state, $window) {
     $state.go('503');
   }
 
-  function stateChangeStart(event, toState, toParams, fromState, fromParams, options) {
+  function stateChangeStart() {
     vm.isLoading = lnCmsClientService.hasLoader();
   }
 

--- a/lib/cms.view.directive.js
+++ b/lib/cms.view.directive.js
@@ -2,10 +2,7 @@ angular
   .module('lnCms')
   .directive('lnCmsView', lnCmsView);
 
-lnCmsView.$inject = ['$state', 'lnCmsClientService', '$rootScope'];
-
-function lnCmsView($state, lnCmsClientService, $rootScope) {
-
+function lnCmsView() {
   return {
     restrict: 'E',
     template: '<div class="{{viewClass}}" ui-view></div>',

--- a/lib/cms.view.directive.js
+++ b/lib/cms.view.directive.js
@@ -24,19 +24,17 @@ function lnCmsView($state, lnCmsClientService) {
 
     lnCmsClientService.enableLoadingState = scope.enableLoadingState;
 
-    scope.$watch('staticDef', onStaticChange);
-    scope.$watch('viewDef', onViewChange);
+    scope.$watch('staticDef', _updateScope('staticDef', 'static'));
+    scope.$watch('viewDef', _updateScope('viewDef', 'view'));
 
-    function onStaticChange() {
-      if (scope.staticDef && scope.staticDef.trim() === '') {
-        scope.static = angular.fromJson(scope.staticDef);
-      }
-    }
-
-    function onViewChange() {
-      if (scope.viewDef && scope.viewDef.trim() === '') {
-        scope.view = angular.fromJson(scope.viewDef);
+    function _updateScope(scopeKey, viewKey) {
+      return function() {
+        var data = scope[scopeKey]
+        if ( data && data.trim() !== '') {
+          scope[viewKey] = angular.fromJson(data);
+        }
       }
     }
   }
 }
+

--- a/lib/cms.view.directive.js
+++ b/lib/cms.view.directive.js
@@ -28,18 +28,15 @@ function lnCmsView($state, lnCmsClientService) {
     scope.$watch('viewDef', onViewChange);
 
     function onStaticChange() {
-      if (!scope.staticDef || scope.staticDef.trim() == '') {
-        return;
+      if (scope.staticDef && scope.staticDef.trim() === '') {
+        scope.static = angular.fromJson(scope.staticDef);
       }
-      scope.static = angular.fromJson(scope.staticDef);
     }
 
     function onViewChange() {
-      if (!scope.viewDef || scope.viewDef.trim() == '') {
-        return;
+      if (scope.viewDef && scope.viewDef.trim() === '') {
+        scope.view = angular.fromJson(scope.viewDef);
       }
-
-      scope.view = angular.fromJson(scope.viewDef);
     }
   }
 }

--- a/lib/cms.view.directive.js
+++ b/lib/cms.view.directive.js
@@ -2,39 +2,16 @@ angular
   .module('lnCms')
   .directive('lnCmsView', lnCmsView);
 
-lnCmsView.$inject = ['$state', 'lnCmsClientService'];
+lnCmsView.$inject = ['$state', 'lnCmsClientService', '$rootScope'];
 
-function lnCmsView($state, lnCmsClientService) {
+function lnCmsView($state, lnCmsClientService, $rootScope) {
 
   return {
     restrict: 'E',
-    link: link,
     template: '<div class="{{viewClass}}" ui-view></div>',
     scope: {
-      viewDef: '@',
-      staticDef: '@',
       viewClass: '@',
-      enableLoadingState: '<'
     }
   };
-
-  function link(scope) {
-    scope.static = null;
-    scope.view = null;
-
-    lnCmsClientService.enableLoadingState = scope.enableLoadingState;
-
-    scope.$watch('staticDef', _updateScope('staticDef', 'static'));
-    scope.$watch('viewDef', _updateScope('viewDef', 'view'));
-
-    function _updateScope(scopeKey, viewKey) {
-      return function() {
-        var data = scope[scopeKey]
-        if ( data && data.trim() !== '') {
-          scope[viewKey] = angular.fromJson(data);
-        }
-      }
-    }
-  }
 }
 

--- a/lib/cms.view.directive.js
+++ b/lib/cms.view.directive.js
@@ -31,12 +31,7 @@ function lnCmsView($state, lnCmsClientService) {
       if (!scope.staticDef || scope.staticDef.trim() == '') {
         return;
       }
-
       scope.static = angular.fromJson(scope.staticDef);
-
-      if (!$state.current.abstract) {
-        reloadState();
-      }
     }
 
     function onViewChange() {
@@ -45,18 +40,6 @@ function lnCmsView($state, lnCmsClientService) {
       }
 
       scope.view = angular.fromJson(scope.viewDef);
-
-      if (!$state.current.abstract) {
-        reloadState();
-      }
-    }
-
-    function reloadState() {
-      var request = lnCmsClientService.nextState ? lnCmsClientService.nextState.data.request : false;
-
-      if ((!request && scope.static) || (request && scope.static && scope.view)) {
-        $state.reload();
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ln-cms",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Moxie <developer@getmoxied.net> (https://getmoxied.net)",
   "description": "An angularjs module for loading content from a cms.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "An angularjs module for loading content from a cms.",
   "main": "index.js",
   "dependencies": {
-    "angular-ui-router": "~0.2.18"
+    "angular-ui-router": "~0.2.18",
+    "raf": "^3.2.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -17,8 +18,5 @@
   "bugs": {
     "url": "https://github.com/moxie-lean/ng-cms/issues"
   },
-  "license": "MIT",
-  "devDependencies": {
-    "raf": "^3.2.0"
-  }
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "bugs": {
     "url": "https://github.com/moxie-lean/ng-cms/issues"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "raf": "^3.2.0"
+  }
 }


### PR DESCRIPTION
At the moment the CMS render directives more than once in a same sequence, the main problem was due custom app directives are expecting data from `async` calls so usually those directives has `undefined` such as: 

``` html
  <section class="footer--top">
    <div class="widget footer--left" ln-o-widgets-area ln-widgets="widgets.footer_left"></div>
    <div class="widget footer--center" ln-o-widgets-area ln-widgets="widgets.footer_center"></div>
    <div class="widget footer--right" ln-o-widgets-area ln-widgets="widgets.footer_right"></div>
  </section>
```

This directive is not going to render since is expecting a `widgets` value and at this point is undefied. This is a problem that should be resolved on the application instead of the router since the router should not trigger multiple reload calls on the same page since it's going to render a directive multiple times which causes: 
- Slowness on HTML construction
- timeout, init functions, intervals are created multiple times and are not reliable. 

In order to fix at the application level we just need an `ng-if` where we expect the data such as: 

``` html
  <section class="footer--top" ng-if="!!widgets">
    <div class="widget footer--left" ln-o-widgets-area ln-widgets="widgets.footer_left"></div>
    <div class="widget footer--center" ln-o-widgets-area ln-widgets="widgets.footer_center"></div>
    <div class="widget footer--right" ln-o-widgets-area ln-widgets="widgets.footer_right"></div>
  </section>
```

In this way the directive is recreated by itself once the data is ready from the async call (http request.

Also this was added as a major version in order to avoid breaking other application that relies on multiple `reloads()` on the same app. 
