### PR TITLE
Event for overriding the metadata.

### DIFF
--- a/lib/cms.controller.js
+++ b/lib/cms.controller.js
@@ -26,6 +26,7 @@ function lnCmsController($rootScope, lnCmsClientService, $state, $window) {
   $rootScope.$on('$stateChangeStart', stateChangeStart);
   $rootScope.$on('$stateChangeSuccess', stateChangeSuccess);
   $rootScope.$on('$stateChangeError', stateChangeError);
+  $rootScope.$on('lnCmsSetMeta', setMeta);
 
   function onError() {
     $state.go('503');
@@ -53,5 +54,9 @@ function lnCmsController($rootScope, lnCmsClientService, $state, $window) {
 
   function getCurrentAbsoluteUrl() {
     return $state.href( $state.current.name, $state.params, { absolute: true } );
+  }
+
+  function setMeta( event, meta ) {
+    vm.meta = meta;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ln-cms",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Moxie <developer@getmoxied.net> (https://getmoxied.net)",
   "description": "An angularjs module for loading content from a cms.",
   "main": "index.js",


### PR DESCRIPTION
Required for pages which use request=false (in rooomy)
